### PR TITLE
Add Support for PHP 8.

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4']
+        php-versions: ['7.3', '7.4', '8.0', '8.1']
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A collection of general util-httpities for making common programming tasks easie
 
 ## Requirements
 
-util-http-php requires PHP 7.0 (or later).
+util-http-php requires PHP 7.3 (or later).
 
 ## Composer
 

--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,10 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^7.0"
+        "php": "^7.3 || ^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0",
+        "phpunit/phpunit": "^9.0",
         "squizlabs/php_codesniffer": "^3.2"
     },
     "autoload": {

--- a/tests/Util/HttpTest.php
+++ b/tests/Util/HttpTest.php
@@ -104,13 +104,12 @@ EOT;
      * @group unit
      * @covers ::parseHeaders
      *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage $rawHeaders cannot be whitespace
-     *
      * @return void
      */
     public function parseHeadersWhitespace()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('$rawHeaders cannot be whitespace');
         Http::parseHeaders('');
     }
 
@@ -236,13 +235,13 @@ EOT;
     /**
      * @test
      * @covers ::getQueryParams
-     * @expectedException \Exception
-     * @expectedExceptionMessage Parameter 'stuff' had more than one value but in $collapsedParams
      *
      * @return void
      */
     public function getQueryParamsCollapsedMoreThanOneValue()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Parameter \'stuff\' had more than one value but in $collapsedParams');
         Http::getQueryParams('http://foo.com/bar/?stuff=yeah&stuff=boy&moreStuff=mhmm', ['stuff']);
     }
 
@@ -262,13 +261,13 @@ EOT;
     /**
      * @test
      * @covers ::getQueryParamsCollapsed
-     * @expectedException \Exception
-     * @expectedExceptionMessage Parameter 'boo' is not expected to be an array, but array given
      *
      * @return void
      */
     public function getQueryParamsCollapsedUnexpectedArray()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Parameter \'boo\' is not expected to be an array, but array given');
         $url = 'http://foo.com/bar/?boo=1&foo=bar&boo=2';
         Http::getQueryParamsCollapsed($url);
     }


### PR DESCRIPTION
#### What does this PR do?
Add Support for PHP 8.
Upgrade to PHPUnit 9.
Backwards Breaking; Remove support for PHP 7.2 and older.

#### Checklist
- [  ] Pull request contains a clear definition of changes
- [  ] Tests (either unit, integration, or acceptance) written and passing
- [  ] Relevant documentation produced and/or updated

